### PR TITLE
Release docker-azcopy docker image for Linux/ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 
-dist: bionic
+dist: focal
 
 services:
   - docker
@@ -36,7 +36,24 @@ jobs:
         - LATEST_AZCOPY="$(curl -sLo- https://api.github.com/repos/Azure/azure-storage-azcopy/releases | jq -r '.[0].tag_name' | sed 's/^v//g')"
         - test -n "$LATEST_AZCOPY"
         - export LATEST_AZCOPY
+        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        - sudo apt-get update
+        - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+        - sudo service docker restart
+        - sudo service docker status
+        - docker --version
+        - docker buildx version
       script:
-        - docker build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t docker-azcopy:$TRAVIS_COMMIT .
+        - docker buildx create --name samplekit
+        - docker buildx use samplekit
+        - docker buildx inspect --bootstrap
+        - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+        - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        - travis_wait 30 docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t $DOCKER_USERNAME/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push . >> /dev/null 2>&1 
+        - docker buildx rm samplekit
       after_success:
-        - docker run --rm docker-azcopy:$TRAVIS_COMMIT azcopy --version
+        - docker run --rm $DOCKER_USERNAME/docker-azcopy:$TRAVIS_COMMIT azcopy --version
+
+notifications:
+  email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ ARG GO_VERSION=1.17
 ARG ALPINE_VERSION=3.14
 
 FROM golang:$GO_VERSION-alpine$ALPINE_VERSION as build
-ENV GOARCH=amd64 GOOS=linux
+ENV GOARCH=arm64 GOOS=linux
 WORKDIR /azcopy
 ARG AZCOPY_VERSION
-RUN wget "https://github.com/Azure/azure-storage-azcopy/archive/v$AZCOPY_VERSION.tar.gz" -O src.tgz
-RUN tar xf src.tgz --strip 1 \
- && go build -o azcopy \
- && ./azcopy --version
+RUN wget RUN wget "https://github.com/Azure/azure-storage-azcopy/archive/v10.12.2.tar.gz" -O src.tgz --no-check-certificate
+RUN tar xf src.tgz --strip 1 
+RUN go build -o azcopy 
+RUN ./azcopy --version
 
 FROM alpine:$ALPINE_VERSION as release
 ARG AZCOPY_VERSION


### PR DESCRIPTION
Hi

Package Owner: A J Vigneshwar 

PR change Details:

Patch Details: Following files has been changed :

Dockerfile: Updated GOARCH=arm64 to push the docker images for arm64 and amd64 platforms using buildx.
.travis.yml: Added docker buildx and pushed the latest images for arm64 and amd64 platforms to dockerhub.

PR Description:
Commit message: Release docker-azcopy docker image for Linux/ARM64 

The following file has been created and modified:

Added support of buildx in .travis.yml to build and push the docker image for arm64 and amd64 platforms and updated the distribution to focal.
Updated dockerfile environment variable GOARCH=arm64 to build, test and push the images for latest versions to dockerhub.

Signed-off-by: odidev <odidev@puresoftware.com>

Reviewer: Pruthvi Teja Reddy
Thanks
A J Vigneshwar
